### PR TITLE
Add simple ShaderToy to Unity converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # ConvertShaderFromShaderToy
-ConvertShaderFromShaderToy
+
+This project provides a simple web page that converts ShaderToy GLSL code
+into a basic Unity shader. The user can choose to generate a shader for the
+Universal Render Pipeline (URP) or for the legacy built‑in pipeline (SRP).
+
+Open `web/index.html` in a browser to use the converter. The page uses
+CodeMirror so both the ShaderToy input and Unity shader output are syntax
+highlighted.

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ShaderToy to Unity Shader Converter</title>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/codemirror.min.css" integrity="sha512-UJ1deacBdW3glDLpi0YblrcyhXwjpsezSoWrmjqIB6xnqb6i8w7PXXIMiFSd+hE0zzzYJ5deQkkkTbqxCE99sg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/theme/eclipse.min.css" integrity="sha512-501igOtZyUfEI+uS+RP6etVG/CVKFeTzwyQciuKvHC+jfece5FPA/S9GL5s2GISAb/sf6N+9O+uwZQzQ0XR4Xw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+<style>
+body {
+  font-family: 'Segoe UI', Tahoma, sans-serif;
+  display: flex;
+  height: 100vh;
+  margin: 0;
+  background: #f5f5f5;
+  color: #333;
+}
+
+.CodeMirror {
+  flex: 1;
+  height: calc(100% - 40px);
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: white;
+}
+
+#left, #right {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 20px;
+}
+
+#controls {
+  width: 220px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background: #fff;
+  border-left: 1px solid #e0e0e0;
+  border-right: 1px solid #e0e0e0;
+  box-shadow: inset 0 0 8px rgba(0,0,0,0.05);
+  padding: 20px;
+}
+
+select {
+  margin-top: 5px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  background: #fff;
+  color: #333;
+}
+
+button {
+  margin-top: 10px;
+  padding: 8px 16px;
+  border: none;
+  background: #0078d4;
+  color: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+button:hover {
+  background: #005a9e;
+}
+
+h3 {
+  margin: 0 0 10px 0;
+  font-weight: 600;
+}
+</style>
+</head>
+<body>
+<div id="left">
+  <h3>ShaderToy Script</h3>
+  <textarea id="input" placeholder="Paste ShaderToy code here..."></textarea>
+</div>
+<div id="controls">
+  <label for="target">Target:</label>
+  <select id="target">
+    <option value="urp">Unity URP</option>
+    <option value="srp">Legacy SRP</option>
+  </select>
+  <button onclick="convertShader()">Convert</button>
+</div>
+<div id="right">
+  <h3>Unity Shader</h3>
+  <textarea id="output" readonly></textarea>
+</div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/codemirror.min.js" integrity="sha512-X4GgYUZWnbLju5PIAcUSrDN5hwP1cZMAXN/pO3jfvshMDW60dy5oYi9z+dLHgvrDMFPvB9rxpQFQUAEyyqDrMA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/mode/clike/clike.min.js" integrity="sha512-0E37QQcI4V3M87uY/rRvhfVqlhK/SXxPxq8np5xpoE2mR7BfrpsbR9f7DmqDveoxu48UUfZo0fo0RKZ77N8INA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="translator.js"></script>
+</body>
+</html>

--- a/web/translator.js
+++ b/web/translator.js
@@ -1,0 +1,123 @@
+let inputEditor;
+let outputEditor;
+
+window.addEventListener('load', () => {
+  inputEditor = CodeMirror.fromTextArea(document.getElementById('input'), {
+    lineNumbers: true,
+    mode: 'x-shader/x-fragment',
+    theme: 'eclipse'
+  });
+  outputEditor = CodeMirror.fromTextArea(document.getElementById('output'), {
+    lineNumbers: true,
+    mode: 'x-shader/x-fragment',
+    theme: 'eclipse',
+    readOnly: true
+  });
+});
+
+function convertShader() {
+  const code = inputEditor.getValue();
+  const target = document.getElementById('target').value;
+  const result = shadertoyToUnity(code, target);
+  outputEditor.setValue(result);
+  outputEditor.refresh();
+}
+
+function shadertoyToUnity(code, target) {
+  let body = code;
+  // basic replacements from GLSL to HLSL
+  const replacements = [
+    [/vec2/g, 'float2'],
+    [/vec3/g, 'float3'],
+    [/vec4/g, 'float4'],
+    [/iTime/g, '_Time.y'],
+    [/iResolution/g, '_Resolution'],
+    [/mainImage\s*\(/, 'frag(']
+  ];
+  replacements.forEach(([from, to]) => {
+    body = body.replace(from, to);
+  });
+  return wrapShader(body, target);
+}
+
+function wrapShader(body, target) {
+  if (target === 'urp') return wrapUrp(body);
+  return wrapLegacy(body);
+}
+
+function wrapUrp(body) {
+  return `Shader "Custom/GeneratedURP" {
+  Properties {
+    _MainTex ("Texture", 2D) = "white" {}
+  }
+  SubShader {
+    Tags { "RenderType"="Opaque" "RenderPipeline"="UniversalPipeline" }
+    Pass {
+      HLSLPROGRAM
+      #pragma vertex vert
+      #pragma fragment frag
+      #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+      struct Attributes {
+        float4 positionOS : POSITION;
+        float2 uv : TEXCOORD0;
+      };
+      struct Varyings {
+        float4 positionCS : SV_POSITION;
+        float2 uv : TEXCOORD0;
+      };
+      TEXTURE2D(_MainTex);
+      SAMPLER(sampler_MainTex);
+      Varyings vert(Attributes IN) {
+        Varyings OUT;
+        OUT.positionCS = TransformObjectToHClip(IN.positionOS.xyz);
+        OUT.uv = IN.uv;
+        return OUT;
+      }
+      float4 frag(Varyings IN) : SV_Target {
+${indent(body, 8)}
+      }
+      ENDHLSL
+    }
+  }
+}`;
+}
+
+function wrapLegacy(body) {
+  return `Shader "Custom/GeneratedLegacy" {
+  Properties {
+    _MainTex ("Texture", 2D) = "white" {}
+  }
+  SubShader {
+    Tags { "RenderType"="Opaque" }
+    Pass {
+      CGPROGRAM
+      #pragma vertex vert
+      #pragma fragment frag
+      #include "UnityCG.cginc"
+      struct appdata {
+        float4 vertex : POSITION;
+        float2 uv : TEXCOORD0;
+      };
+      struct v2f {
+        float2 uv : TEXCOORD0;
+        float4 vertex : SV_POSITION;
+      };
+      sampler2D _MainTex;
+      v2f vert(appdata v) {
+        v2f o;
+        o.vertex = UnityObjectToClipPos(v.vertex);
+        o.uv = v.uv;
+        return o;
+      }
+      fixed4 frag(v2f i) : SV_Target {
+${indent(body, 8)}
+      }
+      ENDCG
+    }
+  }
+}`;
+}
+
+function indent(text, spaces) {
+  return text.split('\n').map(line => ' '.repeat(spaces) + line).join('\n');
+}


### PR DESCRIPTION
## Summary
- add a small web app to convert ShaderToy code to Unity shaders
- describe converter usage in README
- restyle the web page with a modern flat design

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684021384be8832380597516bbee0623